### PR TITLE
fixed a bug in recognising an allowed error in lims data retrieval

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES
 
+release 37.4
+ - fixed a bug in recognising an allowed error in lims data retrieval
+
 release 37.3
  - ml_warehouse driver for st::api::lims
  - ml_warehouse loader - use common code for retrieving flowcell LIMs data from the database

--- a/bin/npg_runs2mlwarehouse
+++ b/bin/npg_runs2mlwarehouse
@@ -38,6 +38,7 @@ if ($verbose) {
   }
   warn qq[\nwarehouse loader is running with the following options:\n];
   warn qq[  verbose\t$verbose\n];
+  warn qq[  explain\t$explain\n];
   if (@{$id_run}) {
     my $runs = join q[ ], sort {$a <=> $b} @{$id_run};
     warn qq[  id_run\t$runs\n];

--- a/lib/npg_warehouse/loader/run.pm
+++ b/lib/npg_warehouse/loader/run.pm
@@ -163,9 +163,10 @@ sub _build__flowcell_table_fks {
   try {
     $rs = $self->query_resultset;
   } catch {
-    my $error = q[id_flowcell_lims or flowcell_barcode];
-    if ($_ !~ /$error/xms) {
-      croak $_;
+    my $allowed_error = qr/id_flowcell_lims\sor\sflowcell_barcode/xms;
+    my $error = $_;
+    if ($error !~ $allowed_error) {
+      croak $error;
     }
   };
 


### PR DESCRIPTION
Ability to load runs that have neither batch nor flowcell id has been lost when access to to teh flowcell table had been factored out. Now the bug is fixed and a test for this feature is added.