### PR TITLE
ml_warehouse lims driver - allow for undefined id_run

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -52,6 +52,7 @@ my $builder = npg_tracking::util::build->new(
                     'npg_qc::autoqc::qc_store'                => 0,
                     'npg_qc::autoqc::qc_store::options'       => 0,
                     'npg_qc::autoqc::qc_store::query'         => 0,
+                    'npg_tracking::util::types'               => 0,
                     'npg_tracking::glossary::flowcell'        => 0,
                     'npg_tracking::glossary::run'             => 0,
                     'npg_tracking::glossary::lane'            => 0,

--- a/Changes
+++ b/Changes
@@ -1,7 +1,8 @@
 LIST OF CHANGES
 
+release 37.9
  - Try to figure out id_run from IseqProductMetrics if a flowcell
-   identifier is provided
+   identifier is provided.
  - daemon to continiously repair foreign keys from iseq_product_metrics
    table in ml warehouse to iseq_flowcell table
 

--- a/lib/st/api/lims/ml_warehouse.pm
+++ b/lib/st/api/lims/ml_warehouse.pm
@@ -5,11 +5,11 @@ use MooseX::StrictConstructor;
 use Carp;
 
 use st::api::lims;
+use npg_tracking::util::types;
 use WTSI::DNAP::Warehouse::Schema;
 use WTSI::DNAP::Warehouse::Schema::Result::IseqFlowcell;
-with qw/  
-          npg_tracking::glossary::run
-          npg_tracking::glossary::lane
+
+with qw/  npg_tracking::glossary::lane
           npg_tracking::glossary::tag
           npg_tracking::glossary::flowcell /;
 
@@ -38,10 +38,11 @@ in WTSI::DNAP::Warehouse::Schema.
 id_run, optional attribute.
 
 =cut
-has '+id_run' =>       ( required        => 0,
-                         lazy_build      => 1,
-                       );
-
+has 'id_run' =>       ( isa             => 'Maybe[NpgTrackingRunId]',
+                        is              => 'ro',
+                        required        => 0,
+                        lazy_build      => 1,
+);
 sub _build_id_run {
   my $self = shift;
   if (not $self->has_flowcell_barcode and not $self->has_id_flowcell_lims) {
@@ -315,7 +316,7 @@ __END__
 
 =item Carp
 
-=item npg_tracking::glossary::run
+=item npg_tracking::util::types
 
 =item npg_tracking::glossary::lane
 

--- a/t/10-st-api-lims-ml_warehouse.t
+++ b/t/10-st-api-lims-ml_warehouse.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
-use Test::More tests => 144;
+use Test::More tests => 145;
 use Test::Exception;
+use Test::Warn;
 use Test::Deep;
 use Moose::Meta::Class;
 
@@ -79,11 +80,13 @@ qr/No record retrieved for st::api::lims::ml_warehouse flowcell_barcode 42UMBAAX
       id_flowcell_lims => 22043,
       flowcell_barcode => 'barcode')->query_resultset->count,
     'data retrieved as long as flowcell id is valid');
-  throws_ok { st::api::lims::ml_warehouse->new(
+  my $id_run;
+  warning_like { $id_run = st::api::lims::ml_warehouse->new(
       mlwh_schema      => $schema_wh,
       flowcell_barcode => 'barcode')->id_run }
-    qr/Validation failed for 'NpgTrackingRunId' with value undef/,
-    'error finding id_run if not in product metrics table';
+    qr/No id_run set yet/,
+    'warning finding id_run if not in product metrics table';
+  is($id_run, undef, 'run id undefined');
   throws_ok { st::api::lims::ml_warehouse->new(
                                  mlwh_schema      => $schema_wh,
                                  id_flowcell_lims => 22043,


### PR DESCRIPTION
... to avoid an error in the at::api::lims children() method