### PR TITLE
build ml schema from an existing resultset if present

### DIFF
--- a/lib/st/api/lims/ml_warehouse.pm
+++ b/lib/st/api/lims/ml_warehouse.pm
@@ -90,6 +90,7 @@ has 'iseq_flowcell' =>   ( isa             => 'DBIx::Class::ResultSet',
 );
 sub _build_iseq_flowcell {
   my $self = shift;
+  if ($self->has_query_resultset) { return $self->query_resultset->result_source->schema->resultset(q(IseqFlowcell)); }
   return $self->mlwh_schema->resultset('IseqFlowcell');
 }
 


### PR DESCRIPTION
ensures we propagate a schema passed in and don't try to auto-generate it in the children