### PR TITLE
cache db connection - further fix

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 LIST OF CHANGES
 
  - added tests for 'purpose'
+ - ml_warehouse lims driver refinments to ensure db connection is
+   propagated
 
 release 38.0
  - autonomous ml_warehouse driver which takes query by run id

--- a/lib/st/api/lims/ml_warehouse.pm
+++ b/lib/st/api/lims/ml_warehouse.pm
@@ -90,8 +90,9 @@ has 'iseq_flowcell' =>   ( isa             => 'DBIx::Class::ResultSet',
 );
 sub _build_iseq_flowcell {
   my $self = shift;
-  if ($self->has_query_resultset) { return $self->query_resultset->result_source->schema->resultset(q(IseqFlowcell)); }
-  return $self->mlwh_schema->resultset('IseqFlowcell');
+  my $schema = $self->has_query_resultset ?
+    $self->query_resultset->result_source->schema : $self->mlwh_schema;
+  return $schema->resultset('IseqFlowcell');
 }
 
 #######
@@ -190,7 +191,7 @@ sub _build__lchildren {
       }
     }
   }
-
+  $self->iseq_flowcell(); # In case id_run accessor is called after the children are built
   if (@children) {
     $self->free_query_resultset();
   }

--- a/lib/st/api/lims/ml_warehouse.pm
+++ b/lib/st/api/lims/ml_warehouse.pm
@@ -192,7 +192,7 @@ sub _build__lchildren {
       }
     }
   }
-  $self->iseq_flowcell(); # In case id_run accessor is called after the children are built
+  $self->mlwh_schema(); # Cache db connection
   if (@children) {
     $self->free_query_resultset();
   }

--- a/lib/st/api/lims/ml_warehouse.pm
+++ b/lib/st/api/lims/ml_warehouse.pm
@@ -90,6 +90,7 @@ has 'iseq_flowcell' =>   ( isa             => 'DBIx::Class::ResultSet',
 );
 sub _build_iseq_flowcell {
   my $self = shift;
+  if ($self->has_query_resultset) { return $self->query_resultset->result_source->schema->resultset(q(IseqFlowcell)); }
   return $self->mlwh_schema->resultset('IseqFlowcell');
 }
 


### PR DESCRIPTION
Another way to achive the same result would be not to free query_resultset at the end of _build__lchildren() 