### PR TITLE
Add mapping of globin metric to autoqc load mapping

### DIFF
--- a/lib/npg_warehouse/loader/autoqc.pm
+++ b/lib/npg_warehouse/loader/autoqc.pm
@@ -45,6 +45,7 @@ Readonly::Hash   our %AUTOQC_MAPPING  => {
                            'rna_norm_5_prime_coverage'     => 'end_5_norm',
                            'rna_intronic_rate'             => 'intronic_rate',
                            'rna_transcripts_detected'      => 'transcripts_detected',
+                           'rna_globin_percent_tpm'        => 'globin_pct_tpm',
                          },
 };
 

--- a/t/10-npg_warehouse-loader-autoqc.t
+++ b/t/10-npg_warehouse-loader-autoqc.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 120;
+use Test::More tests => 121;
 use Test::Exception;
 use Moose::Meta::Class;
 

--- a/t/10-npg_warehouse-loader-autoqc.t
+++ b/t/10-npg_warehouse-loader-autoqc.t
@@ -241,6 +241,7 @@ local $ENV{TEST_DIR} = q[t];
   cmp_ok(sprintf('%.10f',$auto->{1}->{$plex_key}->{1}->{rna_percent_end_2_reads_sense}), q(==), 98.17338, 'rna - pct end 2 sense reads');
   cmp_ok(sprintf('%.10f',$auto->{1}->{$plex_key}->{1}->{rna_rrna_rate}), q(==), 0.020362793, 'rna - rrna rate');
   cmp_ok(sprintf('%.10f',$auto->{1}->{$plex_key}->{1}->{rna_transcripts_detected}), q(==), 71321, 'rna - transcripts detected');
+  cmp_ok(sprintf('%.10f',$auto->{1}->{$plex_key}->{1}->{rna_globin_percent_tpm}), q(==), 2.71, 'rna - globin percent tpm');
   ok(! exists $auto->{1}->{$plex_key}->{1}->{rna_rrna}, 'rna - rrna not present');
 }
 

--- a/t/10-npg_warehouse-loader-run.t
+++ b/t/10-npg_warehouse-loader-run.t
@@ -704,7 +704,7 @@ subtest 'not loading early stage runs' => sub {
 };
 
 subtest 'rna run' => sub {
-  plan tests => 13;
+  plan tests => 14;
 
   my $id_run = 24975;
   lives_ok {$schema_npg->resultset('Run')->find({id_run => $id_run, })->set_tag($user_id, 'staging')}
@@ -731,6 +731,7 @@ subtest 'rna run' => sub {
   cmp_ok(sprintf('%.10f',$r->rna_percent_end_2_reads_sense), q(==), 98.17338, 'loaded pct end 2 sense reads matches source');
   cmp_ok(sprintf('%.10f',$r->rna_rrna_rate), q(==), 0.020362793, 'loaded rrna rate matches source');
   cmp_ok(sprintf('%.10f',$r->rna_transcripts_detected), q(==), 71321, 'loaded transcripts detected matches source');
+  cmp_ok(sprintf('%.10f',$r->rna_globin_percent_tpm), q(==), 2.71, 'loaded globin pct tpm matches source');
 };
 
 1;

--- a/t/data/runfolders/180130_MS6_24975_A_MS6073474-300V2/Data/Intensities/BAM_basecalls_20180221-165427/no_cal/archive/lane1/qc/24975_1#1.rna_seqc.json
+++ b/t/data/runfolders/180130_MS6_24975_A_MS6073474-300V2/Data/Intensities/BAM_basecalls_20180221-165427/no_cal/archive/lane1/qc/24975_1#1.rna_seqc.json
@@ -69,5 +69,6 @@
   "position": 1,
   "rrna": 38470,
   "rrna_rate": 0.020362793,
-  "tag_index": 1
+  "tag_index": 1,
+  "globin_pct_tpm": 2.71
 }


### PR DESCRIPTION
- Metric to be loaded into iseq_product_metrics table along with
  other RNA-related metrics
- This item had been removed from PR https://github.com/wtsi-npg/npg_ml_warehouse/pull/82
  and needs to be put back now that its depends-on PRs have been
  merged into devel. Namely, npg_qc: https://github.com/wtsi-npg/npg_qc/pull/493
  and ml_warehouse: https://github.com/wtsi-npg/ml_warehouse/pull/89