### PR TITLE
Existing product rows update

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -31,6 +31,7 @@ my $builder = npg_tracking::util::build->new(
                     'npg_testing::db'                   => 0,
                     'npg_tracking::util::build'         => 0,
                     'npg_tracking::util::abs_path'      => 0,
+                    'npg_tracking::glossary::composition::factory::rpt_list' => 0,
                     'npg_qc::autoqc::results::qX_yield' => 0,
                  },
 

--- a/lib/npg_warehouse/fk_repair.pm
+++ b/lib/npg_warehouse/fk_repair.pm
@@ -117,6 +117,8 @@ has '_history'     =>   ( isa        => 'HashRef',
 
 sub _where_query {
   my $h = {};
+  $h->{'position'}             = {q[!=], undef};
+  $h->{'id_run'}               = {q[!=], undef};
   $h->{'id_iseq_flowcell_tmp'} = undef;
   $h->{'tag_index'}            = [undef, {q[!=], 0}];
   return $h;
@@ -124,9 +126,11 @@ sub _where_query {
 
 sub _runs_with_null_fks {
   my $self = shift;
-  my @runs = sort { $a <=> $b } map {$_->id_run} $self->_pmrs->search(
+  my @runs = map {$_->id_run} $self->_pmrs->search(
        $self->_where_query(),
-       {columns   => 'id_run', distinct  => 1}
+       {columns  => 'id_run',
+        distinct => 1,
+        order_by => 'id_run'}
      );
   return @runs;
 }
@@ -258,7 +262,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 Genome Research Limited
+Copyright (C) 2015, 2019 Genome Research Limited
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/lib/npg_warehouse/fk_repair.pm
+++ b/lib/npg_warehouse/fk_repair.pm
@@ -197,12 +197,13 @@ sub _run_once {
     $self->_logger->info(qq[Calling loader for run $id]);
 
     my $loader = npg_warehouse::loader::run->new(
-      verbose    => $self->verbose,
-      explain    => $self->explain,
-      id_run     => $id,
-      schema_npg => $self->schema_npg,
-      schema_qc  => $self->schema_qc,
-      schema_wh  => $self->schema_wh,
+      verbose        => $self->verbose,
+      explain        => $self->explain,
+      id_run         => $id,
+      schema_npg     => $self->schema_npg,
+      schema_qc      => $self->schema_qc,
+      schema_wh      => $self->schema_wh,
+      lims_fk_repair => 1
     );
     $loader->load();
 

--- a/lib/npg_warehouse/loader/autoqc.pm
+++ b/lib/npg_warehouse/loader/autoqc.pm
@@ -84,10 +84,20 @@ Retrieval of autoqc data for loading to the warehouse
 A driver to retrieve autoqc objects, required attribute.
 
 =cut
-has 'autoqc_store' =>    ( isa        => 'npg_qc::autoqc::qc_store',
-                           is         => 'ro',
-                           required   => 1,
-                         );
+has 'autoqc_store' => ( isa      => 'npg_qc::autoqc::qc_store',
+                        is       => 'ro',
+                        required => 1,
+                      );
+
+=head2 mlwh
+
+Boolean flag, false by default.
+
+=cut
+has 'mlwh' => ( isa      => 'Bool',
+                is       => 'ro',
+                required => 0,
+              );
 
 sub _basic_data {
     my ($self, $composition) = @_;
@@ -439,6 +449,7 @@ sub retrieve {
     my $methods = {};
     foreach my $r (@{$collection->results}) {
       my $class_name = $r->class_name;
+      $self->mlwh && ($class_name eq 'contamination') && next;
       my $method_name = exists $AUTOQC_MAPPING{$class_name}
                         ? q[_autoqc_check] : q[_] . $class_name;
       if ($self->can($method_name)) {

--- a/lib/npg_warehouse/loader/run.pm
+++ b/lib/npg_warehouse/loader/run.pm
@@ -521,11 +521,6 @@ sub _load_table {
     my $composition = delete $row->{'composition'};
 
     $self->_filter_column_names($table, $row);
-    my @test = keys %{$row};
-    @test = grep { ! /\Aid_run|position|tag_index\Z/smx } @test;
-    if (!@test) { # no useful data
-      next;
-    }
 
     if ($table eq $PRODUCT_TABLE_NAME && ($composition->num_components == 1)
         && $self->_flowcell_table_fks_exist) {
@@ -593,13 +588,12 @@ sub load {
   };
 
   if ($data) {
-
     try {
       foreach my $table (($RUN_LANE_TABLE_NAME, $PRODUCT_TABLE_NAME)) {
         my $count = $self->_load_table($table);
         if ($self->verbose) {
           warn qq[Loaded $count rows to table $table for run $id_run\n];
-    }
+        }
       }
     } catch {
       my $err = $_;

--- a/lib/npg_warehouse/loader/run.pm
+++ b/lib/npg_warehouse/loader/run.pm
@@ -86,17 +86,6 @@ sub iseq_flowcell {
   return $self->schema_wh->resultset($FLOWCELL_LIMS_TABLE_NAME);
 }
 
-has '_pt_column_names' => (
-  isa        => 'ArrayRef',
-  is         => 'ro',
-  required   => 0,
-  lazy_build => 1,
-);
-sub _build__pt_column_names {
-  my $self = shift;
-  return [$self->schema_wh->resultset($PRODUCT_TABLE_NAME)->result_source->columns()];
-}
-
 has '_rl_column_names' => (
   isa        => 'ArrayRef',
   is         => 'ro',
@@ -277,8 +266,8 @@ sub _build__data {
   my $lane_deplexed_flags = {};
 
   my $data_hash = npg_warehouse::loader::autoqc
-                  ->new(autoqc_store => $self->_autoqc_store)
-                  ->retrieve($self->id_run, $self->schema_npg);
+    ->new(autoqc_store => $self->_autoqc_store, mlwh => 1)
+    ->retrieve($self->id_run, $self->schema_npg);
   my $indexed_lanes = _indexed_lanes_hash($data_hash);
 
   my %digests = map { $_ => $data_hash->{$_}->{'composition'} }
@@ -499,11 +488,6 @@ sub _filter_column_names {
     if ($count) {
       $values->{$name} = $values->{$old_name};
       delete $values->{$old_name};
-    }
-    if (any {$name eq $_} @{$self->_pt_column_names}) {
-      next;
-    } else {
-      delete $values->{$name};
     }
   }
   return;

--- a/t/10-npg_warehouse-fkrepair.t
+++ b/t/10-npg_warehouse-fkrepair.t
@@ -93,11 +93,15 @@ npg_warehouse::loader::run->new(
   my $r = npg_warehouse::fk_repair->new($init);
   is (join(q[ ], $r->_runs_with_null_fks()) , '4486 6998 26291', 'runs to repair detected');
   lives_ok {$r->run()} 'repair runs OK';
+
+  # Delete a row that we cannot update - no data
+  $rs->search({id_run => 6998, position => 4, tag_index => 168})->delete();
+
   is (join(q[ ], $r->_runs_with_null_fks()) , '4486 26291', 'runs to repair are still detected');
 
   my $no_fk_rs = $rs->search({id_run => 4486, id_iseq_flowcell_tmp => undef});
   is ($no_fk_rs->count, 2,
-    'two rows for run 4486 are without the fk (lim sdata missing for lane 5)');
+    'two rows for run 4486 are without the fk (lims data missing for lane 5)');
   @lanes = sort map {$_->position} $no_fk_rs->all;
   is (join(q[ ], @lanes), '1 5', 'no fk for lanes 1 and 5');
 

--- a/t/data/fixtures/wh_npg/200-IseqProductMetric.yml
+++ b/t/data/fixtures/wh_npg/200-IseqProductMetric.yml
@@ -12,6 +12,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 20301
   id_iseq_pr_metrics_tmp: 44033296
+  id_iseq_product: 8671acb3a98b1dad5ec481b82e20e11e5a8587c537f99381093c93cd6fd3251f
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 377
@@ -19,6 +20,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 341
   insert_size_quartile3: 410
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":1}]}'
   mean_bait_coverage: ~
   num_reads: 43654430
   on_bait_percent: ~
@@ -58,6 +60,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 20302
   id_iseq_pr_metrics_tmp: 44033297
+  id_iseq_product: 0d06fd03524f82575436856d70f6c1f1683f972e5dc87e5d7128dcb344a7a63f
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 375
@@ -65,6 +68,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 338
   insert_size_quartile3: 408
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":2}]}'
   mean_bait_coverage: ~
   num_reads: 44106402
   on_bait_percent: ~
@@ -104,6 +108,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44033298
+  id_iseq_product: 9c43d246b167c33bc7e21c1237b168da91be4427fb7345f81df05b4561dff01e
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 375
@@ -111,6 +116,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 340
   insert_size_quartile3: 409
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":3}]}'
   mean_bait_coverage: ~
   num_reads: 43913376
   on_bait_percent: ~
@@ -150,6 +156,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44033299
+  id_iseq_product: bb6c903535b5f39abd779ca988c815ea7fde73f6dc2113cc7830bddfec3b685e
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 190
@@ -157,6 +164,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 174
   insert_size_quartile3: 208
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":4}]}'
   mean_bait_coverage: ~
   num_reads: 56226450
   on_bait_percent: ~
@@ -196,6 +204,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44033300
+  id_iseq_product: f97e7af62fa5cf2ceab52027e3ddc1bb6c265d517927b9abce8620042ac22eb6
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 333
@@ -203,6 +212,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 310
   insert_size_quartile3: 360
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":5}]}'
   mean_bait_coverage: ~
   num_reads: 57300150
   on_bait_percent: ~
@@ -242,6 +252,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 20305
   id_iseq_pr_metrics_tmp: 44033301
+  id_iseq_product: bbef4825615f1dc4a1788c06e947c503c836fa793b5273656e92039279e4dc2e
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 492
@@ -249,6 +260,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 460
   insert_size_quartile3: 523
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":6}]}'
   mean_bait_coverage: ~
   num_reads: 57249316
   on_bait_percent: ~
@@ -288,6 +300,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 20306
   id_iseq_pr_metrics_tmp: 44033302
+  id_iseq_product: 64afd30c30f702a1b3d33434f90ffb843b406493050e574c5cca93c5ef169a9d
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 490
@@ -295,6 +308,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 457
   insert_size_quartile3: 521
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":7}]}'
   mean_bait_coverage: ~
   num_reads: 57440612
   on_bait_percent: ~
@@ -334,6 +348,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 20307
   id_iseq_pr_metrics_tmp: 44033303
+  id_iseq_product: aa83ba8f1cdf395dffc73fceb3632c4d2429dd3a689d57a145d90c47d78ed6a1
   id_run: 4486
   indexing_read_length: ~
   insert_size_median: 490
@@ -341,6 +356,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 457
   insert_size_quartile3: 521
+  iseq_composition_tmp: '{"components":[{"id_run":4486,"position":8}]}'
   mean_bait_coverage: ~
   num_reads: 57236016
   on_bait_percent: ~
@@ -380,6 +396,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108699
+  id_iseq_product: 081aa94030c5bf1e56193c58a610bb61422c3acf1f11d866c4b3a8d7c2fc3c69
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 400
@@ -387,6 +404,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 330
   insert_size_quartile3: 485
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":21}]}'
   mean_bait_coverage: ~
   num_reads: 16176998
   on_bait_percent: ~
@@ -426,6 +444,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108700
+  id_iseq_product: 80d243c6071d1e601e5fee1ee55c628a3aecdef2154bae487c4197525e80496e
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 420
@@ -433,6 +452,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 345
   insert_size_quartile3: 509
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":17}]}'
   mean_bait_coverage: ~
   num_reads: 10761632
   on_bait_percent: ~
@@ -472,6 +492,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108701
+  id_iseq_product: 01ca8fb05a301678a28a88d7b7dc05a9ebfc9863732b0bd450405ccda6b305b3
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -479,6 +500,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 26656
   on_bait_percent: ~
@@ -518,6 +540,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108702
+  id_iseq_product: 86ac01beca1bf5c031b70833547ee194c9ccee2b949b8a531f518622ca6baa7e
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 448
@@ -525,6 +548,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 377
   insert_size_quartile3: 537
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":14}]}'
   mean_bait_coverage: ~
   num_reads: 22361128
   on_bait_percent: ~
@@ -564,6 +588,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108703
+  id_iseq_product: 5c060c377e9b99c05da24e0f8756865c5e9a1da98ee16dac11b4bb03f19fa6c6
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 416
@@ -571,6 +596,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 347
   insert_size_quartile3: 496
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":15}]}'
   mean_bait_coverage: ~
   num_reads: 18486256
   on_bait_percent: ~
@@ -610,6 +636,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108704
+  id_iseq_product: 918eed511b6a51119a28698dc6d8b9ac37b085dc0027606d784f2ac4a0c71a8f
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 380
@@ -617,6 +644,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 317
   insert_size_quartile3: 460
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":20}]}'
   mean_bait_coverage: ~
   num_reads: 13889284
   on_bait_percent: ~
@@ -656,6 +684,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108705
+  id_iseq_product: 9ec79d8ecae66127610f923e4d154cbd5e65267f3c5ed5e562172e29e3f1ad05
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 425
@@ -663,6 +692,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 354
   insert_size_quartile3: 513
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":22}]}'
   mean_bait_coverage: ~
   num_reads: 18193404
   on_bait_percent: ~
@@ -702,6 +732,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108706
+  id_iseq_product: d1ae213244422c539e60bc3821d73450ea4c5bc4f100c3533c0651e82650e06b
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 420
@@ -709,6 +740,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 349
   insert_size_quartile3: 503
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":18}]}'
   mean_bait_coverage: ~
   num_reads: 23285380
   on_bait_percent: ~
@@ -748,6 +780,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108707
+  id_iseq_product: 405097189f2dd1cbb7990d1d8b1bb42e679dfbd585aff5f7e4fc62f1153efe14
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -755,6 +788,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 2647296
   on_bait_percent: ~
@@ -794,6 +828,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108708
+  id_iseq_product: 63019d04694e7af22fa98f3174b9120895ef4774b5e9f55f2da972270eade66b
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 419
@@ -801,6 +836,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 352
   insert_size_quartile3: 504
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":19}]}'
   mean_bait_coverage: ~
   num_reads: 18828152
   on_bait_percent: ~
@@ -840,6 +876,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108709
+  id_iseq_product: 22df0ab329ff6bf40131293a0d55d5b06ce696a3998aa1283cc2dfd07b8fdd05
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 438
@@ -847,6 +884,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 365
   insert_size_quartile3: 531
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":16}]}'
   mean_bait_coverage: ~
   num_reads: 9384472
   on_bait_percent: ~
@@ -886,6 +924,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108710
+  id_iseq_product: 340cbe208a04f6271b6dd753b36580ba5617b8ccaa761709d72ec0b16259469c
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 425
@@ -893,6 +932,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 354
   insert_size_quartile3: 513
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":13}]}'
   mean_bait_coverage: ~
   num_reads: 29084230
   on_bait_percent: ~
@@ -932,6 +972,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108711
+  id_iseq_product: 29ff940014318e0d9b75a01f3b372d14f0b4d8d4cfa5d3abc97a0e458b7e656e
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 393
@@ -939,6 +980,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 322
   insert_size_quartile3: 484
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":1,"tag_index":23}]}'
   mean_bait_coverage: ~
   num_reads: 25564438
   on_bait_percent: ~
@@ -978,6 +1020,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108712
+  id_iseq_product: 1e1412d47246379152a23191c419d864923d41c099b6ba925df5f6e450df8d84
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 354
@@ -985,6 +1028,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 300
   insert_size_quartile3: 423
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":2}]}'
   mean_bait_coverage: ~
   num_reads: 289977198
   on_bait_percent: ~
@@ -1024,6 +1068,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108713
+  id_iseq_product: 2dc81f68bea3a68fc47b9c9883845f0b716573a11f0cb691840cb5e4821a2694
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -1031,6 +1076,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":3,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 44236454
   on_bait_percent: ~
@@ -1070,6 +1116,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108714
+  id_iseq_product: c38c8e65b409d1b5b3b87258ec95fbddf5de371c57aa22fc55a19ec234da52f5
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 314
@@ -1077,6 +1124,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 308
   insert_size_quartile3: 321
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":3,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 2700974
   on_bait_percent: ~
@@ -1116,6 +1164,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108715
+  id_iseq_product: 2204407b7d23d8df776ae910c8d7b093daf6d2b1c356dbde602bcf11aea6be2c
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 363
@@ -1123,6 +1172,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 312
   insert_size_quartile3: 434
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":3,"tag_index":153}]}'
   mean_bait_coverage: ~
   num_reads: 220503342
   on_bait_percent: ~
@@ -1162,6 +1212,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108716
+  id_iseq_product: 99bcb514233c52bdf1365bd70a404448b895660abdc60ebf548e3f8af2579438
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 366
@@ -1169,6 +1220,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 312
   insert_size_quartile3: 440
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":4,"tag_index":152}]}'
   mean_bait_coverage: ~
   num_reads: 238654334
   on_bait_percent: ~
@@ -1208,6 +1260,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108717
+  id_iseq_product: fc99bb022dea68a472c1b580d595e26244e0c8687e947d19eb28a08a760dcacb
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -1215,6 +1268,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":4,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 3193526
   on_bait_percent: ~
@@ -1254,6 +1308,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108718
+  id_iseq_product: 0e02e40a44fb8e14100621e227391ac8e74d3af10e0de0300e646a58e85a3ef1
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 314
@@ -1261,6 +1316,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 308
   insert_size_quartile3: 321
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":4,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 2802536
   on_bait_percent: ~
@@ -1300,6 +1356,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108719
+  id_iseq_product: 7548e97c35a55ffc84717210bb4f4ad21523d5a809a6a97c7f91da5e027a7e7d
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -1307,6 +1364,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":5,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 4500858
   on_bait_percent: ~
@@ -1346,6 +1404,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108720
+  id_iseq_product: 45a7fb221ed5931b4f8c83dd367cb391069c80256ccf2242046c43a6997c0c1b
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 377
@@ -1353,6 +1412,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 325
   insert_size_quartile3: 448
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":5,"tag_index":151}]}'
   mean_bait_coverage: ~
   num_reads: 291622712
   on_bait_percent: ~
@@ -1392,6 +1452,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108721
+  id_iseq_product: fcdf55310e12f8a134e15b629a0e71bbb39156827dec717e068e29ebf8dbd31b
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 314
@@ -1399,6 +1460,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 308
   insert_size_quartile3: 320
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":5,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 3170864
   on_bait_percent: ~
@@ -1438,6 +1500,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108722
+  id_iseq_product: 7ea3eb735453ca6d4edf2e8585fce97944fd7ae7b125fada7358ae9c0cc832af
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 366
@@ -1445,6 +1508,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 318
   insert_size_quartile3: 430
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":6}]}'
   mean_bait_coverage: ~
   num_reads: 303066564
   on_bait_percent: ~
@@ -1484,6 +1548,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108723
+  id_iseq_product: aebe10a29b53f548ffca1676fd30ff401756e1791f26b7b6fdb2f0535a265b5e
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 360
@@ -1491,6 +1556,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 309
   insert_size_quartile3: 430
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":7,"tag_index":149}]}'
   mean_bait_coverage: ~
   num_reads: 287260132
   on_bait_percent: ~
@@ -1530,6 +1596,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108724
+  id_iseq_product: a1a734fce9c37b31d43e82cbd7224d8dadedb9a3c45cb3a2a10dec4dd1d084e5
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -1537,6 +1604,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":7,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 4901560
   on_bait_percent: ~
@@ -1576,6 +1644,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108725
+  id_iseq_product: 0fa59b8a7466fad34ec8057a8a8ff88ecb360772f77049a61be8ed1d5d4b60bf
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 314
@@ -1583,6 +1652,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 308
   insert_size_quartile3: 321
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":7,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 3122812
   on_bait_percent: ~
@@ -1622,6 +1692,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108726
+  id_iseq_product: e12f5b14e3ce4750f144ca50e79c57cd881cfc230e202f4fe5fb9ad3a9247624
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: ~
@@ -1629,6 +1700,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: ~
   insert_size_quartile3: ~
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":8,"tag_index":0}]}'
   mean_bait_coverage: ~
   num_reads: 81879164
   on_bait_percent: ~
@@ -1668,6 +1740,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108727
+  id_iseq_product: 3e711d16558a976c0ca47b027ef0f8696e2586b3bbadededa689971aff508ae2
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 380
@@ -1675,6 +1748,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 320
   insert_size_quartile3: 456
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":8,"tag_index":148}]}'
   mean_bait_coverage: ~
   num_reads: 170016942
   on_bait_percent: ~
@@ -1714,6 +1788,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: ~
   id_iseq_pr_metrics_tmp: 44108728
+  id_iseq_product: 5e264188e6022959bd178e3cc0927069a00f0c40087d6ad903c2319b01f81a30
   id_run: 6998
   indexing_read_length: ~
   insert_size_median: 314
@@ -1721,6 +1796,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 308
   insert_size_quartile3: 320
+  iseq_composition_tmp: '{"components":[{"id_run":6998,"position":8,"tag_index":168}]}'
   mean_bait_coverage: ~
   num_reads: 2119440
   on_bait_percent: ~
@@ -1747,4 +1823,3 @@
   verify_bam_id_average_depth: ~
   verify_bam_id_score: ~
   verify_bam_id_snp_count: ~
-

--- a/t/data/fixtures_stlims_wh/200-IseqProductMetric.yml
+++ b/t/data/fixtures_stlims_wh/200-IseqProductMetric.yml
@@ -12,6 +12,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10691
   id_iseq_pr_metrics_tmp: 191553570
+  id_iseq_product: 581e92ca85c13729acea9597e86eddf5e94e62b10cafa93263e3c18127883c77
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 243
@@ -19,6 +20,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 203
   insert_size_quartile3: 293
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":1}]}'
   mean_bait_coverage: ~
   num_reads: 29323572
   on_bait_percent: ~
@@ -58,6 +60,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10692
   id_iseq_pr_metrics_tmp: 191553571
+  id_iseq_product: 47a18e5a99f5008a502ecd1729e36f406d7b4fbec39fd5b4063cee4037c36f7c
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 246
@@ -65,6 +68,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 205
   insert_size_quartile3: 293
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":2}]}'
   mean_bait_coverage: ~
   num_reads: 31277742
   on_bait_percent: ~
@@ -104,6 +108,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10693
   id_iseq_pr_metrics_tmp: 191553572
+  id_iseq_product: e9b8087831cc90a6aea5011ca6c6cb2185c3082d5e4eb263486547da0fa20d7a
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 245
@@ -111,6 +116,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 205
   insert_size_quartile3: 293
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":3}]}'
   mean_bait_coverage: ~
   num_reads: 30745406
   on_bait_percent: ~
@@ -150,6 +156,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10694
   id_iseq_pr_metrics_tmp: 191553573
+  id_iseq_product: 907b155fe0b8043053d43e0203f79a0f21b7645a5947cfe90501ddabc6d1b6ac
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 191
@@ -157,6 +164,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 176
   insert_size_quartile3: 208
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":4}]}'
   mean_bait_coverage: ~
   num_reads: 28903502
   on_bait_percent: ~
@@ -196,6 +204,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10695
   id_iseq_pr_metrics_tmp: 191553574
+  id_iseq_product: fad48f576a10e8332ba3f02e134f7c8a4bb0dbb4729715ba7dfb521bf610c997
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 243
@@ -203,6 +212,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 205
   insert_size_quartile3: 291
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":5}]}'
   mean_bait_coverage: ~
   num_reads: 30479154
   on_bait_percent: ~
@@ -242,6 +252,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10696
   id_iseq_pr_metrics_tmp: 191553575
+  id_iseq_product: 9e7ad89cc7265d4529fd0eda726646a78e1776f61df7c17d19374ffea61660c1
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 244
@@ -249,6 +260,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 206
   insert_size_quartile3: 295
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":6}]}'
   mean_bait_coverage: ~
   num_reads: 31699058
   on_bait_percent: ~
@@ -288,6 +300,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10697
   id_iseq_pr_metrics_tmp: 191553576
+  id_iseq_product: e5001516d009c889132d7614030718b5d174020c357317a0bffad6725e5f3e50
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 245
@@ -295,6 +308,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 205
   insert_size_quartile3: 293
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":7}]}'
   mean_bait_coverage: ~
   num_reads: 33774266
   on_bait_percent: ~
@@ -334,6 +348,7 @@
   human_percent_mapped: ~
   id_iseq_flowcell_tmp: 10698
   id_iseq_pr_metrics_tmp: 191553577
+  id_iseq_product: 2225f0fa7812b772c7a97bb96884f873c024108ac2ba8a82238b0a3413d9655b
   id_run: 3905
   indexing_read_length: ~
   insert_size_median: 247
@@ -341,6 +356,7 @@
   insert_size_num_modes: ~
   insert_size_quartile1: 207
   insert_size_quartile3: 295
+  iseq_composition_tmp: '{"components":[{"id_run":3905,"position":8}]}'
   mean_bait_coverage: ~
   num_reads: 32495420
   on_bait_percent: ~
@@ -367,4 +383,3 @@
   verify_bam_id_average_depth: ~
   verify_bam_id_score: ~
   verify_bam_id_snp_count: ~
-

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -5,4 +5,4 @@
 [Documentation::RequirePodSections]
 lib_sections    = NAME | SYNOPSIS | DESCRIPTION | SUBROUTINES/METHODS | BUGS AND LIMITATIONS | DEPENDENCIES | CONFIGURATION AND ENVIRONMENT | INCOMPATIBILITIES | AUTHOR | LICENSE AND COPYRIGHT
 [Documentation::PodSpelling]
-stop_words = accessors FindBin flowcell NPG npg DBIx NPGQC qc arg dev plex Gourtovaia autoqc Readonly boolean LIMs mqc multi rpt sequencescape DateTime
+stop_words = accessors FindBin flowcell NPG npg DBIx NPGQC qc arg dev plex Gourtovaia autoqc Readonly boolean LIMs mlwh mqc multi rpt sequencescape DateTime


### PR DESCRIPTION
Built on top of https://github.com/wtsi-npg/npg_ml_warehouse/pull/115
Depends on https://github.com/wtsi-npg/ml_warehouse/pull/104

mlwh loader for iseq_product_metrics table is not deleting and inserting rows, but rather inserting new rows and updating existing ones. The drawbacks compared to delete and insert:
- spurious rows will continue to exist
- if the some data are not relevant any longer (say, rna-related qc results) and the new set of data is loader without deleting the old one beforehand, the unwanted rna-related data will persist.

When the rows are updated, by default the LIMs fk values are not recomputed.

