### PR TITLE
Patched the loader for run parameters XML files.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 LIST OF CHANGES
 
+release 45.4.1
+ - patched the loader for Illumina run parameters XML files so that
+   it does not fail when the glob expression contains only the bracket
+   expansion (this is what the pipeline passes to the script)
+
 release 45.4.0
  - tweak to pacbio loader to deal with different SMRT Link versions
  - add a loader for Illumina run parameters XML files

--- a/lib/npg_warehouse/loader/run_files.pm
+++ b/lib/npg_warehouse/loader/run_files.pm
@@ -102,8 +102,15 @@ sub _build__file_path {
   }
 
   my $glob = $self->path_glob;
+  ######
   # Yes, 'abs_path $_', whatever perlcritic says.
-  my @files = map { abs_path $_ } grep { not -d } glob $glob;
+  #
+  # Have to check for file existence since using a glob expression
+  # like '/home/my/{r,R}unParameters.xml' results in both versions of
+  # the path returned. Using a glob expression like
+  # '/home/my/{r,R}unParam*.xml' returns a single existing path.
+  #
+  my @files = map { abs_path $_ } grep { -e } grep { not -d } glob $glob;
   if (not @files) {
     $self->logcroak('No files found');
   }

--- a/t/10-npg_warehouse-loader-run_files.t
+++ b/t/10-npg_warehouse-loader-run_files.t
@@ -40,7 +40,7 @@ subtest 'create an object' => sub {
 };
 
 subtest 'find file to load' => sub {
-  plan tests => 6;
+  plan tests => 7;
 
   my $input = {schema_wh => $schema, id_run => 45, path_glob =>q[]};  
   my $loader = npg_warehouse::loader::run_files->new($input);
@@ -62,6 +62,11 @@ subtest 'find file to load' => sub {
   my $destination = "$tdir/$name";
   copy("t/data/runfolders/run_params/$name", $destination);
   $input->{path_glob} = "$tdir/{r,R}un*.xml";
+  $loader = npg_warehouse::loader::run_files->new($input);
+  is ($loader->_file_path(), $destination, 'correct file path');
+
+  # This type of input will be used by the pipeline
+  $input->{path_glob} = "$tdir/{r,R}unParameters_NovaSeq.xml";
   $loader = npg_warehouse::loader::run_files->new($input);
   is ($loader->_file_path(), $destination, 'correct file path');
   


### PR DESCRIPTION
Prevent a fail when the glob expression contains only the bracket
expansion (this is what the pipeline passes to the script).