### PR TITLE
Exclude the ci build dependency on npg_irods.

### DIFF
--- a/scripts/install_npg_perl_dependencies.sh
+++ b/scripts/install_npg_perl_dependencies.sh
@@ -17,7 +17,7 @@ cpanm --quiet --notest LWP::Protocol::https
 cpanm --quiet --notest https://github.com/chapmanb/vcftools-cpan/archive/v0.953.tar.gz
 
 # WTSI NPG Perl repo dependencies
-repo_names="perl-dnap-utilities perl-irods-wrap ml_warehouse npg_tracking npg_seq_common npg_qc npg_irods"
+repo_names="perl-dnap-utilities perl-irods-wrap ml_warehouse npg_tracking npg_seq_common npg_qc"
 
 for repo in $repo_names
 do

--- a/scripts/install_npg_perl_dependencies.sh
+++ b/scripts/install_npg_perl_dependencies.sh
@@ -17,7 +17,8 @@ cpanm --quiet --notest LWP::Protocol::https
 cpanm --quiet --notest https://github.com/chapmanb/vcftools-cpan/archive/v0.953.tar.gz
 
 # WTSI NPG Perl repo dependencies
-repo_names="perl-dnap-utilities perl-irods-wrap ml_warehouse npg_tracking npg_seq_common npg_qc"
+# Dependency on perl-irods-wrap comes from npg_qc
+repo_names="perl-dnap-utilities ml_warehouse npg_tracking npg_seq_common perl-irods-wrap npg_qc"
 
 for repo in $repo_names
 do


### PR DESCRIPTION
Following a move of WTSI::NPG::HTS::PacBio::Sequel::APIClient to https://github.com/wtsi-npg/perl-dnap-utilities