### PR TITLE
Use a consistent public attribute name.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 LIST OF CHANGES
 
+release 46.9.1
+ - Bug fix: resolved the discrepancy in the attribute name between the
+   npg_pacbio_runs2mlwarehouse script and the npg_warehouse::loader::pacbio::run
+   class.
+
 release 46.9.0
  - PacBio loader is extended to load the outcomes from PacBio manual QC,
    see https://github.com/wtsi-npg/npg_langqc for information on the system

--- a/lib/npg_warehouse/loader/pacbio/run.pm
+++ b/lib/npg_warehouse/loader/pacbio/run.pm
@@ -48,7 +48,7 @@ has 'run_uuid' =>
    required      => 1,
    documentation => 'The PacBio run unique identifier',);
 
-has '_run_name' =>
+has 'run_name' =>
   (isa           => 'Str',
    is            => 'ro',
    lazy          => 1,
@@ -481,7 +481,7 @@ sub load_run {
 
   my ($run_name, $version);
   try {
-    $run_name = $self->_run_name;
+    $run_name = $self->run_name;
     my @swv   = split /[.]/smx, $self->_run_sw_version;
     $version  = $swv[0];
   } catch {


### PR DESCRIPTION
Convert the PacBio run name attribute from private to public.